### PR TITLE
ci(release): publish to npm with trusted publishing on a version tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,54 @@
+# Publishes mtrl to npm when a version tag is pushed, with npm trusted
+# publishing: the workflow's identity is what npm trusts (configured on
+# npmjs.com for the package), no token is stored, and the release carries
+# provenance. A pre-release version (x.y.z-next.N) goes under the `next`
+# dist-tag, anything else under `latest`.
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      # trusted publishing needs npm 11.5.1 or later
+      - run: npm install -g npm@latest
+
+      - name: The tag must be the package version
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          version="$(node -p "require('./package.json').version")"
+          if [ "$tag" != "$version" ]; then
+            echo "tag v$tag does not match package.json version $version" >&2
+            exit 1
+          fi
+
+      - run: bun install --frozen-lockfile
+
+      # prepublishOnly runs the build (bun run build) before npm packs
+      - name: Publish
+        run: |
+          version="$(node -p "require('./package.json').version")"
+          case "$version" in
+            *-*) tag=next ;;
+            *) tag=latest ;;
+          esac
+          npm publish --provenance --access public --tag "$tag"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -216,3 +216,21 @@ By contributing to mtrl, you agree that your contributions will be licensed unde
 ---
 
 Thank you for contributing to mtrl! Your efforts help make this library better for everyone.
+
+## Releasing
+
+Releases are published by GitHub Actions with npm trusted publishing
+(`.github/workflows/release.yml`); no npm token is involved.
+
+1. On `main`, bump the version in `package.json` in its own commit:
+   `chore(release): x.y.z`. A pre-release is `x.y.z-next.N`.
+2. Tag that commit `vx.y.z` and push the tag:
+
+   ```bash
+   git tag vx.y.z
+   git push origin vx.y.z
+   ```
+
+3. The workflow checks that the tag matches the version, builds, and
+   publishes: a pre-release under the `next` dist-tag, a release under
+   `latest`. `npm view mtrl dist-tags` confirms.

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/floor/mtrl.git"
+    "url": "git+https://github.com/floor/mtrl.git"
   },
   "devDependencies": {
     "@types/jsdom": "^21.1.7",


### PR DESCRIPTION
Agent: Claude Fable 5.1 · implementer

Closes #3.

- `.github/workflows/release.yml`: on a `v*` tag, checks the tag against `package.json`, installs with Bun, publishes with `npm publish --provenance --access public` under `next` for a pre-release version and `latest` otherwise. `permissions: id-token: write`, no token anywhere.
- `npm pkg fix`: the repository URL npm normalised at the last publish.
- `CONTRIBUTING.md`: a Releasing section.

Before merging, or right after, the npm side described in #3 has to be set by a maintainer in the browser (Trusted Publisher: GitHub Actions, `floor/mtrl`, `release.yml`); until it is, a tag push fails at the publish step with a 404 or 403 from npm, which is harmless.

Not tested end to end: the workflow can only run against the real registry. The tag check and the dist-tag choice are plain shell; the publish step is npm's documented trusted-publishing invocation.